### PR TITLE
Add missing `setuptools` dependency for ANGLE build system

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ package_dir =
 
 python_requires = >=3.8
 
-# install_requires =
+install_requires = 
+    setuptools # needed for pkg_resources by ANGLE build system
 
 [options.packages.find]
 where = src
@@ -36,7 +37,6 @@ exclude =
 
 [options.extras_require]
 dev =
-    setuptools
     pytest
     pytest-cov
 


### PR DESCRIPTION
- ANGLE build system requires `setuptools` for `pkg_resources`, this does not appear in ANGLE docs as is a Python 3.12 thing only (`setuptools` is available by default on previous Python versions) 