### PR TITLE
Add build for `iphoneos` and `iphonesimulator`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,18 @@ jobs:
       - name: Build artifacts for macos-universal
         run: angle-builder macos-universal --artifact-output-folder $ANGLE_BUILDER_OUTPUT_FOLDER
 
+      - name: Build artifacts for iphoneos-arm64
+        run: angle-builder iphoneos-arm64 --artifact-output-folder $ANGLE_BUILDER_OUTPUT_FOLDER
+
+      - name: Build artifacts for iphonesimulator-x64
+        run: angle-builder iphonesimulator-x64 --artifact-output-folder $ANGLE_BUILDER_OUTPUT_FOLDER
+
+      - name: Build artifacts for iphonesimulator-arm64
+        run: angle-builder iphonesimulator-arm64 --artifact-output-folder $ANGLE_BUILDER_OUTPUT_FOLDER
+
+      - name: Build artifacts for iphoneall-universal
+        run: angle-builder iphoneall-universal --artifact-output-folder $ANGLE_BUILDER_OUTPUT_FOLDER
+
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/tests/test_angle.py
+++ b/tests/test_angle.py
@@ -66,7 +66,7 @@ def test_generate_build_targets_ios_universal(angle):
     assert len(arm64_iphonesimulator) == 1
     assert len(arm64_iphoneos) == 1
 
-    universal_all_iphone = angle._generate_build_targets("iphone*-universal")
+    universal_all_iphone = angle._generate_build_targets("iphoneall-universal")
 
     assert len(universal_all_iphone) == 3
     assert x64_iphonesimulator[0] in universal_all_iphone


### PR DESCRIPTION
Adds build instructions for:
- `iphoneos-arm64`
- `iphonesimulator-x86_64`
- `iphonesimulator-arm64`
- `iphonesimulator-universal` (fat of `x86_64` and `arm64`)
- `iphoneall-universal` (`xcframework` with `iphoneos-arm64` and `iphonesimulator-universal`