### PR TITLE
Add step to create a release when a new tag is added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,10 @@ jobs:
         with:
           name: macos-angle-artifacts
           path: ${{ env.ANGLE_BUILDER_OUTPUT_FOLDER }}
+
+      - name: Upload artifacts to release
+        uses: softprops/action-gh-release@v0.1.15
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "${{ env.ANGLE_BUILDER_OUTPUT_FOLDER }}/*"
+          draft: true


### PR DESCRIPTION
When a new tag is added, a new release is automatically made, and artifacts get uploaded.