### PR TITLE
Change archive format from `.zip` to `.tar.gz` and change artifact name.

### DIFF
--- a/src/angle_builder/angle.py
+++ b/src/angle_builder/angle.py
@@ -561,7 +561,7 @@ class ANGLE:
         - iphonesimulator-arm64
         - iphoneall-universal
 
-        The produced artifact is a zip file containing:
+        The produced artifact is a .tar.gz archive containing:
         - libEGL
         - libGLESv2
         - include folder
@@ -589,7 +589,7 @@ class ANGLE:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             self._logger.info(
-                "Creating zip for branch %s and output_artifact_mode %s",
+                "Creating archive for branch %s and output_artifact_mode %s",
                 self.branch,
                 output_artifact_mode,
             )
@@ -607,13 +607,10 @@ class ANGLE:
             )
             shutil.copy(license_path, temp_dir)
 
-            # Create a zip file with libs, include folder and LICENSE
+            # Create a .tar.gz archive with libs, include folder and LICENSE
             shutil.make_archive(
-                os.path.join(
-                    output_folder,
-                    f"angle-{self.underlined_branch}-{output_artifact_mode}",
-                ),
-                "zip",
+                os.path.join(output_folder, f"angle-{output_artifact_mode}"),
+                "gztar",
                 root_dir=temp_dir,
                 verbose=True,
             )


### PR DESCRIPTION
- Change archive format from `.zip` to `.tar.gz` (to conform with other archives handled during build / preparation of Kivy dependencies)
- Change the artifact name, to keep the download URL versionable by using only the release name (`https://github.com/kivy/angle-builder/releases/download/${MACOS__ANGLE__VERSION}/angle-macos-universal.tar.gz`)