### PR TITLE
Use `chromium/6261` as a default branch

### DIFF
--- a/src/angle_builder/builder.py
+++ b/src/angle_builder/builder.py
@@ -56,7 +56,7 @@ def parse_args(args):
         "--branch",
         dest="branch",
         help="ANGLE branch to build",
-        default="chromium/6045",
+        default="chromium/6261",
     )
     parser.add_argument(
         "--storage-folder",


### PR DESCRIPTION
This PR sets the default ANGLE branch version to `chromium/6261`.

`chromium/6261` is used by Chromium `122`, so, the latest available stable release.

See: https://chromiumdash.appspot.com/branches