### PR TITLE
Use `chromium/6367` as a default branch

### DIFF
--- a/src/angle_builder/builder.py
+++ b/src/angle_builder/builder.py
@@ -56,7 +56,7 @@ def parse_args(args):
         "--branch",
         dest="branch",
         help="ANGLE branch to build",
-        default="chromium/6261",
+        default="chromium/6367",
     )
     parser.add_argument(
         "--storage-folder",


### PR DESCRIPTION
This PR sets the default ANGLE branch version to `chromium/6367`.

`chromium/6367` is used by Chromium `124`,  which has been recently cut for stable.

See: https://chromiumdash.appspot.com/branches

Fixes issue https://bugs.chromium.org/p/angleproject/issues/detail?id=8477 (that prevented to merge #11 )