### PR TITLE
Use `chromium/6723` as a default branch

### DIFF
--- a/src/angle_builder/builder.py
+++ b/src/angle_builder/builder.py
@@ -56,7 +56,7 @@ def parse_args(args):
         "--branch",
         dest="branch",
         help="ANGLE branch to build",
-        default="chromium/6367",
+        default="chromium/6723",
     )
     parser.add_argument(
         "--storage-folder",


### PR DESCRIPTION
This PR sets the default ANGLE branch version to `chromium/6723`.

`chromium/6723` is used by Chromium `130`,  which is used for `chromium` stable version.

See: https://chromiumdash.appspot.com/branches