### PR TITLE
Use `chromium/6778` as a default branch

### DIFF
--- a/src/angle_builder/angle.py
+++ b/src/angle_builder/angle.py
@@ -122,6 +122,7 @@ class ANGLE:
         common_gn_args = [
             "is_component_build=false",
             "is_debug=false",
+            "angle_enable_wgpu=false",
         ]
 
         if output_artifact_mode in ("macos-arm64", "macos-universal"):

--- a/src/angle_builder/builder.py
+++ b/src/angle_builder/builder.py
@@ -56,7 +56,7 @@ def parse_args(args):
         "--branch",
         dest="branch",
         help="ANGLE branch to build",
-        default="chromium/6367",
+        default="chromium/6778",
     )
     parser.add_argument(
         "--storage-folder",


### PR DESCRIPTION
This PR sets the default ANGLE branch version to `chromium/6778`.

`chromium/6778` is used by Chromium `131`,  which is used for `chromium` stable version.

See: https://chromiumdash.appspot.com/branches