### PR TITLE
Use `chromium/6943` as a default branch

### DIFF
--- a/src/angle_builder/angle.py
+++ b/src/angle_builder/angle.py
@@ -161,6 +161,7 @@ class ANGLE:
                     + [
                         'target_cpu="arm64"',
                         'target_os="ios"',
+                        'target_environment="device"',
                         "ios_enable_code_signing=false",
                     ],
                 }

--- a/src/angle_builder/builder.py
+++ b/src/angle_builder/builder.py
@@ -56,7 +56,7 @@ def parse_args(args):
         "--branch",
         dest="branch",
         help="ANGLE branch to build",
-        default="chromium/6778",
+        default="chromium/6943",
     )
     parser.add_argument(
         "--storage-folder",


### PR DESCRIPTION
This PR sets the default ANGLE branch version to `chromium/6943`.

`chromium/6943` is used by Chromium `133`,  which is used for `chromium` stable version.

🗒️ Now `target_environment` is mandatory on iOS, therefore the appropriate changes have been made.

See: https://chromiumdash.appspot.com/branches