### PR TITLE
Use `chromium/7151` as a default branch

### DIFF
--- a/src/angle_builder/builder.py
+++ b/src/angle_builder/builder.py
@@ -56,7 +56,7 @@ def parse_args(args):
         "--branch",
         dest="branch",
         help="ANGLE branch to build",
-        default="chromium/6943",
+        default="chromium/7151",
     )
     parser.add_argument(
         "--storage-folder",


### PR DESCRIPTION
This PR sets the default ANGLE branch version to `chromium/7151`.

`chromium/7151` is used by Chromium `137`,  which is used for `chromium` stable version (and keep it in sync with https://github.com/DexerBR/skia-builder latest released version)

See: https://chromiumdash.appspot.com/branches